### PR TITLE
fix: add missing GITHUB_ENV in ECR image check step

### DIFF
--- a/.github/workflows/aws-build.yml
+++ b/.github/workflows/aws-build.yml
@@ -396,7 +396,7 @@ jobs:
           echo "ECR check outcome: ${{ steps.check-ecr-tag.outcome }}"
           if [ '${{ steps.check-ecr-tag.outcome }}' == 'failure' ]; then
             echo "Release version is not builded"
-            echo "ECR_IMAGE_EXIST=false" >> $
+            echo "ECR_IMAGE_EXIST=false" >> $GITHUB_ENV
             echo "ECR_IMAGE_EXIST=false" >> $GITHUB_OUTPUT  
 
           elif [ '${{ steps.check-ecr-tag.outcome }}' == 'success' ]; then


### PR DESCRIPTION
## 🐛 Bug Fix

Fixed an issue where Docker builds were not being executed even when the ECR image didn't exist.

### Problem
The `ECR_IMAGE_EXIST` environment variable was not being set correctly when the image doesn't exist in ECR. On line 399, the echo command was missing `$GITHUB_ENV`, causing the variable to not be available for subsequent conditional checks.

### Solution
- Added `$GITHUB_ENV` to the echo command on line 399
- Now `ECR_IMAGE_EXIST=false` is properly set as an environment variable when the image check fails
- Build steps that depend on `env.ECR_IMAGE_EXIST == 'false'` will now execute correctly

### Impact
- Docker builds will now execute when images don't exist in ECR
- Prevents skipped builds that should have run
- Fixes the workflow logic for staging environment deployments

### Testing
The fix ensures that when `aws ecr describe-images` fails (ImageNotFoundException), the workflow correctly identifies that the image doesn't exist and proceeds with the build process.